### PR TITLE
Designed base data signer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,25 @@
 # Data Signer
 
+This library provides a logic for digital signing and validating of a binary data.
+
+Inputs and outputs are binary data, don't be afraid to use the [`petrknap/binary`](https://github.com/petrknap/php-binary).
+
+
+## Usage
+
+```php
+namespace PetrKnap\DataSigner;
+
+$signer = new SomeDataSigner();
+
+$data = 'some data';
+$signature = $signer->sign($data);
+
+if ($signer->verify($data, $signature)) {
+    echo 'Data was successfully verified by signature.';
+}
+```
+
 ---
 
 Run `composer require petrknap/data-signer` to install it.

--- a/composer.json
+++ b/composer.json
@@ -30,10 +30,12 @@
   "license": "LGPL-3.0-or-later",
   "name": "petrknap/data-signer",
   "require": {
-    "php": ">=8.1"
+    "php": ">=8.1",
+    "petrknap/binary": "^4.0"
   },
   "require-dev": {
     "nunomaduro/phpinsights": "^2.11",
+    "petrknap/shorts": "^3.0",
     "phpstan/phpstan": "^1.12",
     "squizlabs/php_codesniffer": "^3.7",
     "phpunit/phpunit": "^10.5"

--- a/src/DataSigner.php
+++ b/src/DataSigner.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PetrKnap\DataSigner;
+
+/**
+ * @note Use {@see DataSignerInterface} if you need strong cross-platform compatibility.
+ */
+abstract class DataSigner implements DataSignerInterface
+{
+    public function sign(
+        string $data,
+    ): Signature {
+        return new Signature(
+            rawSignature: $this->generateRawSignature(
+                data: $data,
+            ),
+        );
+    }
+
+    public function verify(
+        string $data,
+        Signature|string $signature,
+    ): bool {
+        $signature = is_string($signature) ? Signature::fromBinary($signature) : $signature;
+        $expectedSignature = $this->sign(
+            data: $data,
+        );
+        return $signature->rawSignature === $expectedSignature->rawSignature;
+    }
+
+    /**
+     * @param string $data binary representation of a data
+     *
+     * @return string binary representation of a signature
+     */
+    abstract protected function generateRawSignature(string $data): string;
+}

--- a/src/DataSignerInterface.php
+++ b/src/DataSignerInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PetrKnap\DataSigner;
+
+/**
+ * @note Use {@see DataSigner} if you want to have access to full functionality.
+ */
+interface DataSignerInterface
+{
+    /**
+     * @param string $data binary representation of a data
+     */
+    public function sign(
+        string $data,
+    ): Signature;
+
+    /**
+     * @param string $data binary representation of a data
+     * @param Signature|string $signature instance or binary representation of a signature
+     */
+    public function verify(
+        string $data,
+        Signature|string $signature,
+    ): bool;
+}

--- a/src/Signature.php
+++ b/src/Signature.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PetrKnap\DataSigner;
+
+use PetrKnap\Binary\BinariableInterface;
+use PetrKnap\Binary\BinariableTrait;
+use PetrKnap\Binary\Serializer;
+
+final class Signature implements BinariableInterface, Serializer\SelfSerializerInterface
+{
+    use BinariableTrait;
+
+    public function __construct(
+        public readonly string $rawSignature,
+    ) {
+    }
+
+    public function toBinary(): string
+    {
+        return $this->rawSignature;
+    }
+
+    public static function fromBinary(string $data): self
+    {
+        return new self(
+            rawSignature: $data,
+        );
+    }
+}

--- a/tests/DataSignerTest.php
+++ b/tests/DataSignerTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PetrKnap\DataSigner;
+
+final class DataSignerTest extends DataSignerTestCase
+{
+    protected static function getDataSigner(): DataSigner
+    {
+        return new SomeDataSigner();
+    }
+
+    protected static function getRawSignatures(): iterable
+    {
+        return [
+            'data' => self::DATA,
+        ];
+    }
+}

--- a/tests/DataSignerTestCase.php
+++ b/tests/DataSignerTestCase.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PetrKnap\DataSigner;
+
+use PHPUnit\Framework\TestCase;
+
+abstract class DataSignerTestCase extends TestCase
+{
+    protected const DATA = 'data';
+
+    public function testWorksWithRawSignature(): void
+    {
+        $dataSigner = static::getDataSigner();
+        $rawSignature = static::getRawSignatures()['data'];
+
+        self::assertSame($rawSignature, $dataSigner->sign(self::DATA)->toBinary());
+        self::assertTrue($dataSigner->verify(self::DATA, $rawSignature));
+    }
+
+    /**
+     * @dataProvider dataSignsData
+     */
+    public function testSignsData(
+        DataSigner $dataSigner,
+        Signature $expectedSignature,
+    ): void {
+        self::assertEquals(
+            $expectedSignature,
+            $dataSigner->sign(
+                data: self::DATA,
+            ),
+        );
+    }
+
+    public static function dataSignsData(): iterable
+    {
+        $dataSigner = static::getDataSigner();
+        $rawSignatures = static::getRawSignatures();
+        $makeSignature = static fn (string $rawSignature): Signature => new Signature(
+            rawSignature: $rawSignature,
+        );
+        return [
+            'data' => [
+                $dataSigner,
+                $makeSignature($rawSignatures['data']),
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataVerifiesDataBySignature
+     */
+    public function testVerifiesDataBySignature(
+        DataSigner $dataSigner,
+        Signature $signature,
+    ): void {
+        self::assertTrue($dataSigner->verify(
+            data: self::DATA,
+            signature: $signature,
+        ));
+    }
+
+    public static function dataVerifiesDataBySignature(): iterable
+    {
+        return static::dataSignsData();
+    }
+
+    /**
+     * @dataProvider dataDoesNotVerifyDataBySignature
+     */
+    public function testDoesNotVerifyDataBySignature(
+        DataSigner $dataSigner,
+        Signature $signature,
+    ): void {
+        self::assertFalse($dataSigner->verify(
+            data: self::DATA,
+            signature: $signature,
+        ));
+    }
+
+    public static function dataDoesNotVerifyDataBySignature(): iterable
+    {
+        $dataSigner = static::getDataSigner();
+        return [
+            'modified data' => [
+                $dataSigner,
+                $dataSigner->sign('signed data'),
+            ],
+            'modified signature' => [
+                $dataSigner,
+                new Signature(
+                    rawSignature: 'modified signature',
+                ),
+            ],
+        ];
+    }
+
+    abstract protected static function getDataSigner(): DataSigner;
+
+    /**
+     * @return array<non-empty-string, string>
+     */
+    abstract protected static function getRawSignatures(): iterable;
+}

--- a/tests/ReadmeTest.php
+++ b/tests/ReadmeTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PetrKnap\DataSigner;
+
+use PetrKnap\Shorts\PhpUnit\MarkdownFileTestInterface;
+use PetrKnap\Shorts\PhpUnit\MarkdownFileTestTrait;
+use PHPUnit\Framework\TestCase;
+
+final class ReadmeTest extends TestCase implements MarkdownFileTestInterface
+{
+    use MarkdownFileTestTrait;
+
+    public static function getPathToMarkdownFile(): string
+    {
+        return __DIR__ . '/../README.md';
+    }
+
+    public static function getExpectedOutputsOfPhpExamples(): iterable
+    {
+        return [
+            'basic-usage' => 'Data was successfully verified by signature.',
+        ];
+    }
+}

--- a/tests/SomeDataSigner.php
+++ b/tests/SomeDataSigner.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PetrKnap\DataSigner;
+
+final class SomeDataSigner extends DataSigner
+{
+    protected function generateRawSignature(string $data): string
+    {
+        return $data;
+    }
+}


### PR DESCRIPTION
- [x] This pull request does not contain any breaking change.
- [x] I asked [the AI](https://copilot.microsoft.com/) to briefly summarize, use and improve the feature(s), and I'm okay with the output:
<!-- ⇅ remove it if it doesn't make sense ⇅ -->
<!-- ↓ here belongs the AI inputs (>>) and outputs (>) ↓ -->
>> Could you briefly summarize the following code for me?
>> ```php
>> interface DataSignerInterface
>> {
>>     public function sign(
>>         string $data,
>>     ): Signature;
>>
>>     public function verify(
>>         string $data,
>>         Signature|string $signature,
>>     ): bool;
>> }
>> ```
>
> This code defines an interface named `DataSignerInterface`, which outlines the contract for a data signing and verification system. It includes:
> 1. **`sign` Method**: Takes a `string` (data to be signed) as input and returns a `Signature` object.
> 2. **`verify` Method**: Validates the provided data and its associated signature (either a `Signature` object or a string representation of it) and returns a `bool` indicating whether the verification was successful.
>
> The interface ensures any implementing class will adhere to these methods, promoting consistency and flexibility for signing and verifying data. Let me know if you'd like further insights!
>
>> Could you show me how to use it?
>
> Certainly! Here's an example of how you might use the `DataSignerInterface` in practice.
>
> Let's assume you have a concrete class called `HmacDataSigner` that implements the `DataSignerInterface`. With the `HmacDataSigner` implemented, you can use it as follows:
> ```php
> $key = 'supersecretkey';
> $dataSigner = new HmacDataSigner($key);
> 
> $data = 'This is the data to be signed.';
> 
> // Signing the data
> $signature = $dataSigner->sign($data);
> echo 'Signature: ' . base64_encode($signature->getValue()) . PHP_EOL;
> 
> // Verifying the signature
> $isValid = $dataSigner->verify($data, $signature);
> echo 'Is the signature valid? ' . ($isValid ? 'Yes' : 'No') . PHP_EOL;
> ```
>
>> Is there any way to do the interface better?
>
> Instead of relying on primitive types like `string`, consider introducing more specific value objects (e.g., `Data`, `Key`, `Signature`). This would make the interface more descriptive and type-safe.
