### PR TITLE
Implemented support for domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,18 +7,32 @@ Inputs and outputs are binary data, don't be afraid to use the [`petrknap/binary
 
 ## Usage
 
+The **basic use** of [a `DataSigner`](./src/DataSignerInterface.php) is quite simple:
 ```php
 namespace PetrKnap\DataSigner;
 
 $signer = new SomeDataSigner();
-
 $data = 'some data';
 $signature = $signer->sign($data);
-
 if ($signer->verify($data, $signature)) {
     echo 'Data was successfully verified by signature.';
 }
 ```
+
+### Domain-specific signing
+
+If you need to **limit the validity** of the signature **to a specific purpose** (domain), just set it to [the `DataSigner`](./src/DataSigner.php):
+```php
+namespace PetrKnap\DataSigner;
+
+$signer = new SomeDataSigner();
+$data = 'some data';
+$signature = $signer->withDomain('password_reset')->sign($data);
+if (!$signer->withDomain('cookies')->verify($data, $signature)) {
+    echo 'You can not use signature generated for `password_reset` in `cookies`.';
+}
+```
+
 
 ---
 

--- a/src/DataSigner.php
+++ b/src/DataSigner.php
@@ -9,12 +9,17 @@ namespace PetrKnap\DataSigner;
  */
 abstract class DataSigner implements DataSignerInterface
 {
+    public function __construct(
+        private readonly string|null $domain = null,
+    ) {
+    }
+
     public function sign(
         string $data,
     ): Signature {
         return new Signature(
             rawSignature: $this->generateRawSignature(
-                data: $data,
+                data: $this->domain . $data,
             ),
         );
     }
@@ -29,6 +34,13 @@ abstract class DataSigner implements DataSignerInterface
         );
         return $signature->rawSignature === $expectedSignature->rawSignature;
     }
+
+    /**
+     * @param non-empty-string|null $domain
+     *
+     * @return static with given domain
+     */
+    abstract public function withDomain(string|null $domain): static;
 
     /**
      * @param string $data binary representation of a data

--- a/src/HmacDataSigner.php
+++ b/src/HmacDataSigner.php
@@ -16,7 +16,20 @@ final class HmacDataSigner extends DataSigner
         private readonly string $hashAlgorithm,
         #[SensitiveParameter]
         private readonly string $key,
+        string|null $domain = null,
     ) {
+        parent::__construct(
+            domain: $domain,
+        );
+    }
+
+    public function withDomain(string|null $domain): static
+    {
+        return new self(
+            hashAlgorithm: $this->hashAlgorithm,
+            key: $this->key,
+            domain: $domain,
+        );
     }
 
     protected function generateRawSignature(string $data): string

--- a/tests/DataSignerTest.php
+++ b/tests/DataSignerTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace PetrKnap\DataSigner;
 
+/**
+ * @note Tests internal implementation of {@see DataSigner} via {@see SomeDataSigner}.
+ */
 final class DataSignerTest extends DataSignerTestCase
 {
     protected static function getDataSigner(): DataSigner
@@ -15,6 +18,7 @@ final class DataSignerTest extends DataSignerTestCase
     {
         return [
             'data' => self::DATA,
+            'domain + data' => self::DOMAIN . self::DATA,
         ];
     }
 }

--- a/tests/DataSignerTestCase.php
+++ b/tests/DataSignerTestCase.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 abstract class DataSignerTestCase extends TestCase
 {
     protected const DATA = 'data';
+    protected const DOMAIN = 'domain';
 
     public function testWorksWithRawSignature(): void
     {
@@ -45,6 +46,10 @@ abstract class DataSignerTestCase extends TestCase
             'data' => [
                 $dataSigner,
                 $makeSignature($rawSignatures['data']),
+            ],
+            'domain + data' => [
+                $dataSigner->withDomain(self::DOMAIN),
+                $makeSignature($rawSignatures['domain + data']),
             ],
         ];
     }
@@ -93,6 +98,10 @@ abstract class DataSignerTestCase extends TestCase
                 new Signature(
                     rawSignature: 'modified signature',
                 ),
+            ],
+            'wrong domain' => [
+                $dataSigner->withDomain('wrong domain'),
+                $dataSigner->withDomain(self::DOMAIN)->sign(self::DATA),
             ],
         ];
     }

--- a/tests/HmacDataSignerTest.php
+++ b/tests/HmacDataSignerTest.php
@@ -15,6 +15,7 @@ final class HmacDataSignerTest extends DataSignerTestCase
     {
         return [
             'data' => base64_decode('GywWt1vSqHDBFBU8zaW8/KYzFLxyL6Fg1pDeEzzLuds='),
+            'domain + data' => base64_decode('9DBXdOVO+vhWvm6F5ZSE8Np6cSaeVnsEPIxelmKZIic='),
         ];
     }
 }

--- a/tests/ReadmeTest.php
+++ b/tests/ReadmeTest.php
@@ -20,7 +20,8 @@ final class ReadmeTest extends TestCase implements MarkdownFileTestInterface
     public static function getExpectedOutputsOfPhpExamples(): iterable
     {
         return [
-            'basic-usage' => 'Data was successfully verified by signature.',
+            'usage' => 'Data was successfully verified by signature.',
+            'domain-specific-signing' => 'You can not use signature generated for `password_reset` in `cookies`.',
         ];
     }
 }

--- a/tests/SomeDataSigner.php
+++ b/tests/SomeDataSigner.php
@@ -5,10 +5,17 @@ declare(strict_types=1);
 namespace PetrKnap\DataSigner;
 
 /**
- * Dummy implementation for testing purposes
+ * @itnernal dummy implementation for testing and demonstration purposes
  */
 final class SomeDataSigner extends DataSigner
 {
+    public function withDomain(string|null $domain): static
+    {
+        return new self(
+            domain: $domain,
+        );
+    }
+
     protected function generateRawSignature(string $data): string
     {
         return $data;


### PR DESCRIPTION
- [x] This pull request does not contain any breaking change.
- [x] I asked [the AI](https://copilot.microsoft.com/) to briefly summarize, use and improve the feature(s), and I'm okay with the output:
<!-- ⇅ remove it if it doesn't make sense ⇅ -->
<!-- ↓ here belongs the AI inputs (>>) and outputs (>) ↓ -->
>> Could you briefly summarize the following code for me?
>> ```php
>> class DataSigner {
>>     // ...
>>     /**
>>      * @param non-empty-string|null $domain
>>      *
>>      * @return static with given domain
>>      */
>>     public function withDomain(string|null $domain): static {
>>         // ...
>>     }
>> }
>> ```
>
> This code defines a method `withDomain` within the `DataSigner` class. Here’s what it does:
> - **Parameter**: Accepts a `string` that must be non-empty or `null`. This parameter represents the `domain` to be associated with the instance.
> - **Return Type**: Returns a new instance of the same class (`static`) with the specified domain applied.
> - **Purpose:** Enables creating a modified copy of the `DataSigner` object with a specified domain, following an immutable design pattern (i.e., the original instance remains unchanged).
>
>> Could you show me how to use it?
>
> Certainly! Here's an example of how to use the `withDomain` method from the `DataSigner` class, assuming it follows an immutable design pattern (returns a modified copy without changing the original instance):
> ```php
> $dataSigner = new DataSigner();
> 
> // Create a new instance with a specific domain
> $dataSignerWithDomain = $dataSigner->withDomain('example');
> 
> // Create another instance without a domain
> $dataSignerWithoutDomain = $dataSigner->withDomain(null);
> ```