### PR TITLE
Implemented support for time-limited signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Inputs and outputs are binary data, don't be afraid to use the [`petrknap/binary
 
 The **basic use** of [a `DataSigner`](./src/DataSignerInterface.php) is quite simple:
 ```php
-namespace PetrKnap\DataSigner;
+use PetrKnap\DataSigner\SomeDataSigner;
 
 $signer = new SomeDataSigner();
 $data = 'some data';
@@ -21,15 +21,29 @@ if ($signer->verify($data, $signature)) {
 
 ### Domain-specific signing
 
-If you need to **limit the validity** of the signature **to a specific purpose** (domain), just set it to [the `DataSigner`](./src/DataSigner.php):
+If you need to **limit the validity** of the signature **to a specific purpose** (domain), just set it to [the `DataSigner` object](./src/DataSigner.php):
 ```php
-namespace PetrKnap\DataSigner;
+use PetrKnap\DataSigner\SomeDataSigner;
 
 $signer = new SomeDataSigner();
 $data = 'some data';
 $signature = $signer->withDomain('password_reset')->sign($data);
 if (!$signer->withDomain('cookies')->verify($data, $signature)) {
     echo 'You can not use signature generated for `password_reset` in `cookies`.';
+}
+```
+
+### Time-limited signing
+
+If you need to **limit the validity** of the signature **to specific time** (expiration), just give it to [the `DataSigner::sign()` method](./src/DataSigner.php):
+```php
+use PetrKnap\DataSigner\SomeDataSigner;
+
+$signer = new SomeDataSigner();
+$data = 'some data';
+$signature = $signer->sign($data, expiresAt: new DateTimeImmutable('2025-04-05 09:40:53+02:00'));
+if (!$signer->verify($data, $signature)) {
+    echo 'You can not use signature after its expiration.';
 }
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
   "name": "petrknap/data-signer",
   "require": {
     "php": ">=8.1",
-    "petrknap/binary": "^4.0"
+    "petrknap/binary": "^4.0",
+    "psr/clock": "^1.0"
   },
   "require-dev": {
     "nunomaduro/phpinsights": "^2.11",

--- a/src/HmacDataSigner.php
+++ b/src/HmacDataSigner.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PetrKnap\DataSigner;
 
+use Psr\Clock\ClockInterface;
 use SensitiveParameter;
 
 final class HmacDataSigner extends DataSigner
@@ -17,9 +18,11 @@ final class HmacDataSigner extends DataSigner
         #[SensitiveParameter]
         private readonly string $key,
         string|null $domain = null,
+        ClockInterface|null $clock = null,
     ) {
         parent::__construct(
             domain: $domain,
+            clock: $clock,
         );
     }
 
@@ -29,6 +32,7 @@ final class HmacDataSigner extends DataSigner
             hashAlgorithm: $this->hashAlgorithm,
             key: $this->key,
             domain: $domain,
+            clock: $this->clock,
         );
     }
 

--- a/src/Signature.php
+++ b/src/Signature.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PetrKnap\DataSigner;
 
+use DateTimeImmutable;
+use DateTimeInterface;
 use PetrKnap\Binary\BinariableInterface;
 use PetrKnap\Binary\BinariableTrait;
 use PetrKnap\Binary\Serializer;
@@ -12,20 +14,50 @@ final class Signature implements BinariableInterface, Serializer\SelfSerializerI
 {
     use BinariableTrait;
 
+    private const KEY_RAW_SIGNATURE = 0;
+    private const KEY_EXPIRES_AT = 1;
+
     public function __construct(
         public readonly string $rawSignature,
+        public readonly DateTimeInterface|null $expiresAt,
     ) {
     }
 
     public function toBinary(): string
     {
-        return $this->rawSignature;
+        if ($this->expiresAt === null) {
+            return $this->rawSignature;
+        }
+        return self::getSerializer()->serialize([
+            self::KEY_RAW_SIGNATURE => $this->rawSignature,
+            self::KEY_EXPIRES_AT => (int) $this->expiresAt->format('U'),
+        ]);
     }
 
     public static function fromBinary(string $data): self
     {
+        try {
+            /** @var array<int, string|int> $unserialized */
+            $unserialized = @self::getSerializer()->unserialize($data); // @todo move suppression to binary package
+            /** @var string $rawSignature */
+            $rawSignature = $unserialized[self::KEY_RAW_SIGNATURE]
+                ?? throw new Serializer\Exception\CouldNotUnserializeData(__METHOD__, $data);
+            $rawExpiresAt = $unserialized[self::KEY_EXPIRES_AT]
+                ?? throw new Serializer\Exception\CouldNotUnserializeData(__METHOD__, $data);
+            /** @var DateTimeImmutable|null $expiresAt */
+            $expiresAt = DateTimeImmutable::createFromFormat('U', (string) $rawExpiresAt);
+        } catch (Serializer\Exception\SerializerException) {
+            $rawSignature = $data;
+            $expiresAt = null;
+        }
         return new self(
-            rawSignature: $data,
+            rawSignature: $rawSignature,
+            expiresAt: $expiresAt,
         );
+    }
+
+    private static function getSerializer(): Serializer\SerializerInterface
+    {
+        return new Serializer\Php();
     }
 }

--- a/tests/DataSignerTest.php
+++ b/tests/DataSignerTest.php
@@ -4,21 +4,27 @@ declare(strict_types=1);
 
 namespace PetrKnap\DataSigner;
 
+use Psr\Clock\ClockInterface;
+
 /**
  * @note Tests internal implementation of {@see DataSigner} via {@see SomeDataSigner}.
  */
 final class DataSignerTest extends DataSignerTestCase
 {
-    protected static function getDataSigner(): DataSigner
+    protected static function getDataSigner(ClockInterface $clock): DataSigner
     {
-        return new SomeDataSigner();
+        return new SomeDataSigner(
+            clock: $clock,
+        );
     }
 
     protected static function getRawSignatures(): iterable
     {
         return [
             'data' => self::DATA,
+            'data + expiresAt' => self::DATA . self::getClock()->now()->getTimestamp(),
             'domain + data' => self::DOMAIN . self::DATA,
+            'domain + data + expiresAt' => self::DOMAIN . self::DATA . self::getClock()->now()->getTimestamp(),
         ];
     }
 }

--- a/tests/HmacDataSignerTest.php
+++ b/tests/HmacDataSignerTest.php
@@ -4,18 +4,26 @@ declare(strict_types=1);
 
 namespace PetrKnap\DataSigner;
 
+use Psr\Clock\ClockInterface;
+
 final class HmacDataSignerTest extends DataSignerTestCase
 {
-    protected static function getDataSigner(): DataSigner
+    protected static function getDataSigner(ClockInterface $clock): DataSigner
     {
-        return new HmacDataSigner('sha256', 'secret');
+        return new HmacDataSigner(
+            hashAlgorithm: 'sha256',
+            key: 'secret',
+            clock: $clock,
+        );
     }
 
     protected static function getRawSignatures(): iterable
     {
         return [
             'data' => base64_decode('GywWt1vSqHDBFBU8zaW8/KYzFLxyL6Fg1pDeEzzLuds='),
+            'data + expiresAt' => base64_decode('gz98uKKzzuxdIPRI305Ouq9YHNKxzonaIPZHFM+MZJY='),
             'domain + data' => base64_decode('9DBXdOVO+vhWvm6F5ZSE8Np6cSaeVnsEPIxelmKZIic='),
+            'domain + data + expiresAt' => base64_decode('oVGUfzBMm+nY/cdS7GNhHBZUS/5zyWN57NLXrxmaCXY='),
         ];
     }
 }

--- a/tests/ReadmeTest.php
+++ b/tests/ReadmeTest.php
@@ -22,6 +22,7 @@ final class ReadmeTest extends TestCase implements MarkdownFileTestInterface
         return [
             'usage' => 'Data was successfully verified by signature.',
             'domain-specific-signing' => 'You can not use signature generated for `password_reset` in `cookies`.',
+            'time-limited-signing' => 'You can not use signature after its expiration.',
         ];
     }
 }

--- a/tests/SignatureTest.php
+++ b/tests/SignatureTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PetrKnap\DataSigner;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+
+final class SignatureTest extends TestCase
+{
+    /**
+     * @dataProvider dataConvertsItself
+     */
+    public function testConvertsItselfToBinary(Signature $signature, string $expectedBinary): void
+    {
+        self::assertEquals(
+            $expectedBinary,
+            $signature->toBinary(),
+        );
+    }
+
+    /**
+     * @dataProvider dataConvertsItself
+     */
+    public function testConvertsItselfFromBinary(Signature $expectedSignature, string $binary): void
+    {
+        self::assertEquals(
+            $expectedSignature,
+            Signature::fromBinary($binary),
+        );
+    }
+
+    public static function dataConvertsItself(): iterable
+    {
+        return [
+            'rawSignature' => [
+                new Signature(
+                    rawSignature: 'rawSignature',
+                    expiresAt: null,
+                ),
+                'rawSignature',
+            ],
+            'rawSignature + expiresAt' => [
+                new Signature(
+                    rawSignature: 'rawSignature',
+                    expiresAt: new DateTimeImmutable('2024-04-05T09:26:54+02:00'),
+                ),
+                'a:2:{i:0;s:12:"rawSignature";i:1;i:1712302014;}',
+            ],
+        ];
+    }
+}

--- a/tests/SomeDataSigner.php
+++ b/tests/SomeDataSigner.php
@@ -13,6 +13,7 @@ final class SomeDataSigner extends DataSigner
     {
         return new self(
             domain: $domain,
+            clock: $this->clock,
         );
     }
 


### PR DESCRIPTION
- [ ] This pull request does not contain any breaking change.
- [x] I asked [the AI](https://copilot.microsoft.com/) to briefly summarize, use and improve the feature(s), and I'm okay with the output:
<!-- ⇅ remove it if it doesn't make sense ⇅ -->
<!-- ↓ here belongs the AI inputs (>>) and outputs (>) ↓ -->
>> Could you briefly summarize meaning of `expiresAt` from the following code for me?
>> ```php
>> class DataSigner {
>>     // ...
>>         public function sign(
>>         string $data,
>>         DateTimeInterface|null $expiresAt = null,
>>     ): Signature {
>>         // ...
>>     }
>> }
>> ```
>
> The `expiresAt` parameter in the `sign` method allows you to optionally specify a timestamp (`DateTimeInterface`) when the signature will expire. If provided, the signature is associated with this expiration date, meaning it will be considered invalid beyond that point. If `expiresAt` is `null`, the signature does not have an expiration and remains valid indefinitely. This adds flexibility for time-bound usage scenarios of the signature.
>
>> Could you show me how to use it?
>
> Certainly! Here's an example of how you can use the `expiresAt` parameter in the `sign` method of the `DataSigner` class:
> ```php
> $dataSigner = new DataSigner();
> 
> $data = 'Important data to be signed.';
> $expiration = new DateTimeImmutable('2025-12-31 23:59:59');
> 
> // Signing with an expiration date
> $signatureWithExpiration = $dataSigner->sign($data, $expiration);
> echo 'Signature with expiration: ' . base64_encode($signatureWithExpiration->getValue()) . PHP_EOL;
> 
> // Signing without an expiration date
> $signatureWithoutExpiration = $dataSigner->sign($data, null);
> echo 'Signature without expiration: ' . base64_encode($signatureWithoutExpiration->getValue()) . PHP_EOL;
> ```
>
>> Is there any way to do it better?
>
> Yes, the current design can be improved in a few ways to make it more robust, flexible, and user-friendly. Here are some suggestions to enhance the `sign` method and the `expiresAt` functionality:
> - Use a Dedicated Value Object for Expiration
> - Set Default Expiration Values
> - Add Expiration Validation in Signature
> - Separate Expiration Logic
> - Enforce Expiration Requirements with Typed Parameters
> - Provide Helper Methods for Expiration
