### PR TITLE
Implemented `SignableDataInterface`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ Inputs and outputs are binary data, don't be afraid to use the [`petrknap/binary
 
 ## Usage
 
-The **basic use** of [a `DataSigner`](./src/DataSignerInterface.php) is quite simple:
+The **basic use** of [a Data Signer interface](./src/DataSignerInterface.php) is quite simple:
 ```php
-use PetrKnap\DataSigner\SomeDataSigner;
+use PetrKnap\DataSigner\Some;
 
-$signer = new SomeDataSigner();
+$signer = new Some\DataSigner();
 $data = 'some data';
 $signature = $signer->sign($data);
 if ($signer->verify($data, $signature)) {
@@ -21,11 +21,11 @@ if ($signer->verify($data, $signature)) {
 
 ### Domain-specific signing
 
-If you need to **limit the validity** of the signature **to a specific purpose** (domain), just set it to [the `DataSigner` object](./src/DataSigner.php):
+If you need to **limit the validity** of the signature **to a specific purpose** (domain), just set it to [the Data Signer service](./src/DataSigner.php):
 ```php
-use PetrKnap\DataSigner\SomeDataSigner;
+use PetrKnap\DataSigner\Some;
 
-$signer = new SomeDataSigner();
+$signer = new Some\DataSigner();
 $data = 'some data';
 $signature = $signer->withDomain('password_reset')->sign($data);
 if (!$signer->withDomain('cookies')->verify($data, $signature)) {
@@ -35,16 +35,38 @@ if (!$signer->withDomain('cookies')->verify($data, $signature)) {
 
 ### Time-limited signing
 
-If you need to **limit the validity** of the signature **to specific time** (expiration), just give it to [the `DataSigner::sign()` method](./src/DataSigner.php):
+If you need to **limit the validity** of the signature **to specific time** (expiration), just give it to [the Data Signer's method sign](./src/DataSigner.php):
 ```php
-use PetrKnap\DataSigner\SomeDataSigner;
+use PetrKnap\DataSigner\Some;
 
-$signer = new SomeDataSigner();
+$signer = new Some\DataSigner();
 $data = 'some data';
 $signature = $signer->sign($data, expiresAt: new DateTimeImmutable('2025-04-05 09:40:53+02:00'));
 if (!$signer->verify($data, $signature)) {
     echo 'You can not use signature after its expiration.';
 }
+```
+
+### Signable data transfer object
+
+If you **communicate through data transfer objects**, you can use [a Signable Data interface](./src/SignableDataInterface.php):
+```php
+use PetrKnap\DataSigner\Some;
+
+$apiClient = new class (new Some\DataSigner()) {
+    public function __construct(private readonly Some\DataSigner $dataSigner) {}
+    public function put(Some\DataTransferObject $payload): void {
+        $signature = $this->dataSigner->sign($payload);
+        $requestBody = [
+            ...$payload->jsonSerialize(),
+            'signature' => $signature->encode()->base64()->getData(),
+        ];
+        echo json_encode($requestBody);  # here should be the API call
+    }
+};
+$apiClient->put(new Some\DataTransferObject(
+    property: 'some value',
+));
 ```
 
 

--- a/src/DataSigner.php
+++ b/src/DataSigner.php
@@ -28,9 +28,10 @@ abstract class DataSigner implements DataSignerInterface
     }
 
     public function sign(
-        string $data,
+        SignableDataInterface|string $data,
         DateTimeInterface|null $expiresAt = null,
     ): Signature {
+        $data = is_string($data) ? $data : $data->toSignableData();
         return new Signature(
             rawSignature: $this->generateRawSignature(
                 data: $this->domain . $data . $expiresAt?->getTimestamp(),
@@ -40,7 +41,7 @@ abstract class DataSigner implements DataSignerInterface
     }
 
     public function verify(
-        string $data,
+        SignableDataInterface|string $data,
         Signature|string $signature,
     ): bool {
         $signature = is_string($signature) ? Signature::fromBinary($signature) : $signature;

--- a/src/DataSignerInterface.php
+++ b/src/DataSignerInterface.php
@@ -10,18 +10,18 @@ namespace PetrKnap\DataSigner;
 interface DataSignerInterface
 {
     /**
-     * @param string $data binary representation of a data
+     * @param SignableDataInterface|string $data signable data instance or binary representation of a data
      */
     public function sign(
-        string $data,
+        SignableDataInterface|string $data,
     ): Signature;
 
     /**
-     * @param string $data binary representation of a data
-     * @param Signature|string $signature instance or binary representation of a signature
+     * @param SignableDataInterface|string $data signable data instance or binary representation of a data
+     * @param Signature|string $signature signature instance or binary representation of a signature
      */
     public function verify(
-        string $data,
+        SignableDataInterface|string $data,
         Signature|string $signature,
     ): bool;
 }

--- a/src/SignableDataInterface.php
+++ b/src/SignableDataInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PetrKnap\DataSigner;
+
+interface SignableDataInterface
+{
+    /**
+     * @return string signable by {@see DataSignerInterface}
+     */
+    public function toSignableData(): string;
+}

--- a/tests/DataSignerTest.php
+++ b/tests/DataSignerTest.php
@@ -7,13 +7,13 @@ namespace PetrKnap\DataSigner;
 use Psr\Clock\ClockInterface;
 
 /**
- * @note Tests internal implementation of {@see DataSigner} via {@see SomeDataSigner}.
+ * @note Tests internal implementation of {@see DataSigner} via {@see Some\DataSigner}.
  */
 final class DataSignerTest extends DataSignerTestCase
 {
     protected static function getDataSigner(ClockInterface $clock): DataSigner
     {
-        return new SomeDataSigner(
+        return new Some\DataSigner(
             clock: $clock,
         );
     }

--- a/tests/ReadmeTest.php
+++ b/tests/ReadmeTest.php
@@ -23,6 +23,7 @@ final class ReadmeTest extends TestCase implements MarkdownFileTestInterface
             'usage' => 'Data was successfully verified by signature.',
             'domain-specific-signing' => 'You can not use signature generated for `password_reset` in `cookies`.',
             'time-limited-signing' => 'You can not use signature after its expiration.',
+            'signable-data-transfer-object' => '{"property":"some value","signature":"c29tZSB2YWx1ZQ=="}',
         ];
     }
 }

--- a/tests/Some/DataSigner.php
+++ b/tests/Some/DataSigner.php
@@ -2,12 +2,14 @@
 
 declare(strict_types=1);
 
-namespace PetrKnap\DataSigner;
+namespace PetrKnap\DataSigner\Some;
+
+use PetrKnap\DataSigner\DataSigner as AbstractDataSigner;
 
 /**
- * @itnernal dummy implementation for testing and demonstration purposes
+ * @internal dummy implementation for testing and demonstration purposes
  */
-final class SomeDataSigner extends DataSigner
+final class DataSigner extends AbstractDataSigner
 {
     public function withDomain(string|null $domain): static
     {

--- a/tests/Some/DataTransferObject.php
+++ b/tests/Some/DataTransferObject.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PetrKnap\DataSigner\Some;
+
+use JsonSerializable;
+use PetrKnap\DataSigner\SignableDataInterface;
+
+/**
+ * @internal dummy implementation for testing and demonstration purposes
+ */
+final class DataTransferObject implements JsonSerializable, SignableDataInterface
+{
+    public function __construct(
+        public readonly string $property,
+    ) {
+    }
+
+    public function toSignableData(): string
+    {
+        return $this->property;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'property' => $this->property,
+        ];
+    }
+}


### PR DESCRIPTION
- [ ] This pull request does not contain any breaking change.
- [x] I asked [the AI](https://copilot.microsoft.com/) to briefly summarize, use and improve the feature(s), and I'm okay with the output:
<!-- ⇅ remove it if it doesn't make sense ⇅ -->
<!-- ↓ here belongs the AI inputs (>>) and outputs (>) ↓ -->
>> Could you briefly summarize purpose of the SignableInterface from the following code for me?
>> ```php
>> interface SignableInterface {
>>     /**
>>      * @return string binary representation of this object for {@see DataSignerInterface}
>>      */
>>     public function toSignableData(): string;
>> }
>> interface DataSignerInterface {
>>     public function sign(
>>         SignableInterface|string $data,
>>     ): Signature;
>>     public function verify(
>>         SignableInterface|string $data,
>>         Signature|string $signature,
>>     ): bool;
>> }
>> ```
>
> The purpose of the `SignableInterface` is to define a contract for objects that can be signed by a `DataSignerInterface`. It requires implementing classes to provide a method, `toSignableData`, which returns a binary representation of the object. This representation is used by `DataSignerInterface` for signing (`sign`) and verifying (`verify`) operations. It allows flexible handling of both string data and objects implementing `SignableInterface`.
>
>> Could you show me how to use it?
>
> Certainly! Here's an example of how to use the `SignableInterface` along with the `DataSignerInterface` for signing and verifying custom objects that implement `SignableInterface`.
>
> First, create a class that implements `SignableInterface`. This class should provide its binary representation through the `toSignableData` method:
> ```php
> class Document implements SignableInterface
> {
>     private string $content;
> 
>     public function __construct(string $content)
>     {
>         $this->content = $content;
>     }
> 
>     public function toSignableData(): string
>     {
>         // Convert content into its binary representation
>         return $this->content;
>     }
> }
> ```
> 
> Here's how you can use the `SignableInterface` and `DataSignerInterface` together:
> ```php
> $key = 'supersecretkey';
> $dataSigner = new HmacDataSigner($key);
> 
> // Create a signable object
> $document = new Document('This is important content.');
> 
> // Sign the object
> $signature = $dataSigner->sign($document);
> echo 'Signature: ' . base64_encode($signature->getValue()) . PHP_EOL;
> 
> // Verify the object
> $isValid = $dataSigner->verify($document, $signature);
> echo 'Is the signature valid? ' . ($isValid ? 'Yes' : 'No') . PHP_EOL;
> ```
>
>> Is there any way to name the interface or its method better?
>
> Certainly! Naming an interface and its methods can make your code easier to understand and maintain. Here are some suggestions to improve clarity and semantic meaning for your `SignableInterface` and its `toSignableData` method:
> 
> **Better Naming for the Interface:**
> 1. Focus on Purpose - these names clarify that the interface is for objects, resources, or content that can be signed
>    - `SignableObjectInterface`
>    - `SignableResourceInterface`
>    - `SignableContentInterface`
> 2. Relation to Signing - these options emphasize the relationship with signing and how they are used
>    - `SigningEntityInterface`
>    - `SignableRepresentationInterface`
>    - `SignablePayloadInterface`
>
> **Better Naming for the Method:**
> 1. Descriptive of Output - these names focus on the method's function, which converts the object into a format suitable for signing.
>    - `toBinaryRepresentation`
>    - `toSigningPayload`
>    - `toSignatureData`
> 2. Focused on Action - these names reflect the action of preparing or converting the object for the signing process
>    - `serializeForSigning`
>    - `convertToSignable`
>    - `prepareForSigning`
>
> With improved naming, your interface could look like this:
> ```php
> interface SignablePayloadInterface {
>     /**
>      * @return string binary representation of this object for {@see DataSignerInterface}
>      */
>     public function toSigningPayload(): string;
> }
> ```
>
> These changes clarify the purpose and the functionality of the interface and its method, making it more intuitive to use and understand. Let me know which direction resonates with you or if you'd like to explore more options!
> 
>> Why do you think that your SigningPayload is better than original SignableData?
>
> I wouldn't say one is inherently better, but "SigningPayload" and "SignableData" each have strengths depending on how they align with your goals for naming clarity, semantics, and the context in which they're used. Here's a side-by-side reasoning to clarify why I leaned toward "SigningPayload" in certain cases:
>
> **Why SigningPayload Could Be Preferred:**
> 1. **Action-Oriented Semantics:** "Payload" suggests that the object is actively being processed (specifically for signing), aligning with a signing workflow. This makes it feel like the object is ready for immediate use in the signing operation.
> 2. **Domain-Specific Context:** "Payload" is a well-established term in cryptography, APIs, and communication protocols, so it might feel more familiar in projects where these terms are used.
> 3. **Emphasis on State:** "SigningPayload" conveys that the object has already been prepared for signing (e.g., serialized or converted into the necessary binary format).
>
> **Why SignableData Is Also Strong:**
> 1. **Potential for Reusability:** "Signable" emphasizes capability—it highlights that the object can be signed, which might resonate better in contexts where "data" flows through multiple stages and isn't yet tied to a specific operation.
> 2. **Clarity:** The combination of "Signable" and "Data" directly conveys the purpose: data that is eligible for signing.
> 3. **Simplicity:** It's direct and easy to understand, which is a benefit when collaborating with developers who may not come from a cryptographic or specialized background.
> 
> **Conclusion:**
> If the interface and its method are used in a domain-specific signing context and you want to reflect readiness and action, **SigningPayload** might feel like a sharper fit. On the other hand, if your focus is on general-purpose, flexible design, **SignableData**'s simplicity and reusability might be more suitable.
>
> It's about what resonates most with your project's purpose and style. Which direction feels more aligned with the goals of your interface? Let me know if you'd like further input!
