### PR TITLE
Implemented `SignableHttpRequest`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,20 @@
 This library provides a logic for digital signing and validating of a binary data.
 
 Inputs and outputs are binary data, don't be afraid to [use the `petrknap/binary`](https://github.com/petrknap/php-binary).
+The data are only signed (readable), [use the `petrknap/crypto-sodium`](https://github.com/petrknap/php-crypto-sodium) if you need to encrypt them.
 
+- Implementations
+  - [Edwards-curve Digital Signature Algorithm (Ed25519)](./src/Ed25519DataSigner.php)
+  - [Hash-based Message Authentication Code (HMAC)](./src/HmacDataSigner.php)
+  - [Sodium (Ed25519)](./src/SodiumDataSigner.php)
+- Usage
+  - [Basic use](#usage)
+  - [Domain-specific signing](#domain-specific-signing)
+  - [Time-limited signing](#time-limited-signing)
+  - [Signable HTTP request](#signable-http-request)
+  - [Signable data transfer object](#signable-data-transfer-object)
+  - [Communication trough 3rd party machine](#communication-trough-3rd-party-machine)
 
-## Implementations
-
-- [Edwards-curve Digital Signature Algorithm (Ed25519)](./src/Ed25519DataSigner.php)
-- [Hash-based Message Authentication Code (HMAC)](./src/HmacDataSigner.php)
-- [Sodium (Ed25519)](./src/SodiumDataSigner.php)
 
 
 ## Usage
@@ -26,6 +33,7 @@ if ($signer->verify($data, $signature)) {
 }
 ```
 
+
 ### Domain-specific signing
 
 If you need to **limit the validity** of the signature **to a specific purpose** (domain), just set it to [the Data Signer service](./src/DataSigner.php):
@@ -40,6 +48,7 @@ if (!$signer->withDomain('cookies')->verify($data, $signature)) {
 }
 ```
 
+
 ### Time-limited signing
 
 If you need to **limit the validity** of the signature **to specific time** (expiration), just give it to [the Data Signer's method sign](./src/DataSigner.php):
@@ -53,6 +62,48 @@ if (!$signer->verify($data, $signature)) {
     echo 'You can not use signature after its expiration.';
 }
 ```
+
+
+### Signable HTTP request
+
+If you **communicate trough HTTP**, you can use [a Signable HTTP Request](./src/SignableHttpRequest.php).
+The following **example is more complex and uses asymmetric cryptography** to show you how to use it **the best way**.
+You can simply make it symmetric by change of the data signer.
+```php
+namespace PetrKnap\DataSigner;
+
+# Sender side
+$apiSigner = new Ed25519DataSigner(secretKey: base64_decode('o8DJ9Tp7MT0nOjzzpnrjNQswHHJgwVKrtGgzwWlflaNua/ZaQnutowbocwmRQ1FaJ0C5tJg0jBe8rBay1sOvzQ=='));
+$apiRequest = new \GuzzleHttp\Psr7\Request(
+    method: 'GET',
+    uri: 'https://example.com/api/items',
+    headers: [
+        'X-User-Id' => 89,
+    ],
+);
+$apiRequest = $apiRequest->withHeader(
+    'X-Signature',
+    (string) $apiSigner->sign(new Some\SignableHttpRequest($apiRequest))->encode()->base64(),
+);
+echo $apiRequest->getHeaderLine('X-Signature');  # here should be the HTTP client call
+
+# Receiver side
+$usersPublicKeyMap = [
+    89 => base64_decode('bmv2WkJ7raMG6HMJkUNRWidAubSYNIwXvKwWstbDr80='),
+];
+$userId = $apiRequest->getHeaderLine('X-User-Id');
+$apiSigner = new Ed25519DataSigner(publicKey: $usersPublicKeyMap[$userId] ?? throw new \Exception('User not found'));
+if ( ! $apiSigner->verify(new Some\SignableHttpRequest($apiRequest), base64_decode($apiRequest->getHeaderLine('X-Signature')))) {
+    throw new \Exception('Unauthorized request');
+}
+echo "Request was authorized and verified for user `{$userId}` and now can be processed.";
+```
+
+As this use case has two sides, [use only the basic implementation](#usage) which will generate signature without additional data.
+On the other side can be someone who can not use the same implementation of data signer.
+
+This example is build over `libsodium`, so **it can be used across platforms and languages**.
+
 
 ### Signable data transfer object
 
@@ -75,6 +126,7 @@ $apiClient->put(new Some\DataTransferObject(
 ));
 ```
 
+
 ### Communication trough 3rd party machine
 
 If you need to **sign data forwarded trough 3rd party machine** (f.e. by token or cookie), you can use [the Signature with data](./src/Signature.php):
@@ -94,9 +146,6 @@ $verifiedUserIdentifier = $signer->withDomain('password_reset')->verified(
 )->orElseThrow();
 echo "Verified user identifier is `{$verifiedUserIdentifier}`.";
 ```
-
-**WARNING:** The data are only signed (readable), [use the `petrknap/crypto-sodium`](https://github.com/petrknap/php-crypto-sodium) if you need to encrypt them.
-
 
 ---
 

--- a/composer.json
+++ b/composer.json
@@ -49,10 +49,12 @@
   },
   "require-dev": {
     "ext-sodium": "*",
+    "guzzlehttp/psr7": "^2.8",
     "nunomaduro/phpinsights": "^2.11",
     "petrknap/crypto-sodium": "*",
     "phpstan/phpstan": "^1.12",
     "phpunit/phpunit": "^10.5",
+    "psr/http-message": "^2.0",
     "squizlabs/php_codesniffer": "^3.7"
   },
   "scripts": {

--- a/src/SignableHttpRequest.php
+++ b/src/SignableHttpRequest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PetrKnap\DataSigner;
+
+/**
+ * @note Defines a shared contract; implement your environment‑specific version.
+ *
+ * @see Some\SignableHttpRequest for inspiration
+ */
+abstract class SignableHttpRequest implements SignableDataInterface
+{
+    protected readonly string $method;
+    /**
+     * @var array<string, string>
+     */
+    protected readonly array $headers;
+
+    /**
+     * @param array<string, string> $headers
+     */
+    public function __construct(
+        string $method,
+        protected readonly string $uri,
+        array $headers,
+        protected readonly string $body,
+    ) {
+        $this->method = static::normalizeMethod($method);
+        $this->headers = static::normalizeHeaders($headers);
+    }
+
+    /**
+     * @return non-empty-string HTTP/1.1-like - headers are normalized by {@see static::normalizeHeaders()}
+     *
+     * @link https://datatracker.ietf.org/doc/html/rfc2616
+     */
+    public function toSignableData(): string
+    {
+        $http11Like = ["{$this->method} {$this->uri} HTTP/1.1"];
+        foreach ($this->headers as $name => $value) {
+            $http11Like[] = "{$name}: {$value}";
+        }
+        $http11Like[] = '';
+        $http11Like[] = $this->body;
+
+        return implode("\r\n", $http11Like);
+    }
+
+    /**
+     * @param array<string, string> $headers
+     *
+     * @return array<string, string>
+     */
+    protected static function normalizeHeaders(array $headers): array
+    {
+        ksort($headers); // stabilize merge
+        $normalizedHeaders = $prenormalizedHeaders = [];
+        foreach ($headers as $name => $value) {
+            $normalizedName = implode('-', array_map('ucfirst', explode('-', strtolower($name))));
+            $stringValue = (string) $value;
+            if (array_key_exists($normalizedName, $prenormalizedHeaders)) {
+                $prenormalizedHeaders[$normalizedName][] = $stringValue;
+            } else {
+                $prenormalizedHeaders[$normalizedName] = [$stringValue];
+            }
+        }
+        foreach ($prenormalizedHeaders as $key => $values) {
+            sort($values);
+            $normalizedHeaders[$key] = implode(',', $values);
+        }
+        ksort($normalizedHeaders); // stabilize output
+        return $normalizedHeaders;
+    }
+
+    protected static function normalizeMethod(string $method): string
+    {
+        return strtoupper($method);
+    }
+}

--- a/tests/ReadmeTest.php
+++ b/tests/ReadmeTest.php
@@ -23,6 +23,8 @@ final class ReadmeTest extends TestCase implements MarkdownFileTestInterface
             'usage' => 'Data was successfully verified by signature.',
             'domain-specific-signing' => 'You can not use signature generated for `password_reset` in `cookies`.',
             'time-limited-signing' => 'You can not use signature after its expiration.',
+            'signable-http-request' => '/waNdA8dx9VtObrajrs/NQ6UNrFw6hvozsY/yLdS1l5krg4Dj5pkUOQeeieChq+Bj/bQusVy/3+qGQDP7TUACQ==' .
+                'Request was authorized and verified for user `89` and now can be processed.',
             'signable-data-transfer-object' => '{"payload":{"property":"some value"},"signature":"c29tZSB2YWx1ZQ=="}',
             'communication-trough-3rd-party-machine' => 'Verified user identifier is `some_user`.',
         ];

--- a/tests/SignableHttpRequestTest.php
+++ b/tests/SignableHttpRequestTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PetrKnap\DataSigner;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class SignableHttpRequestTest extends TestCase
+{
+    #[DataProvider('dataConvertsToSignableData')]
+    public function testConvertsToSignableData(string $method, string $uri, array $headers, string $body, string $expectedSignableData): void
+    {
+        self::assertSame($expectedSignableData, (new class (
+            method: $method,
+            uri: $uri,
+            headers: $headers,
+            body: $body,
+        ) extends SignableHttpRequest {
+        })->toSignableData());
+    }
+
+    public static function dataConvertsToSignableData(): array
+    {
+        return [
+            'request' => ['POST', 'path?que=ry', ['he-ad' => 'er'], 'body', <<<EoS
+POST path?que=ry HTTP/1.1\r
+He-Ad: er\r
+\r
+body
+EoS],
+            'lower-cased method' => ['method', 'uri', ['he-ad' => 'er'], 'body', <<<EoS
+METHOD uri HTTP/1.1\r
+He-Ad: er\r
+\r
+body
+EoS],
+            'upper-cased header' => ['METHOD', 'uri', ['HE-AD' => 'ER'], 'body', <<<EoS
+METHOD uri HTTP/1.1\r
+He-Ad: ER\r
+\r
+body
+EoS],
+            'unsorted headers' => ['METHOD', 'uri', ['b' => 3, 'a' => 2, 'B' => 1], 'body', <<<EoS
+METHOD uri HTTP/1.1\r
+A: 2\r
+B: 1,3\r
+\r
+body
+EoS],
+            'empty headers' => ['METHOD', 'uri', [], 'body', <<<EoS
+METHOD uri HTTP/1.1\r
+\r
+body
+EoS],
+            'empty body' => ['METHOD', 'uri', ['he-ad' => 'er'], '', <<<EoS
+METHOD uri HTTP/1.1\r
+He-Ad: er\r
+\r
+
+EoS],
+            'duplicate header' => ['METHOD', 'uri', ['he-ad' => 'er', 'HE-AD' => 'ER'], '', <<<EoS
+METHOD uri HTTP/1.1\r
+He-Ad: ER,er\r
+\r
+
+EoS],
+        ];
+    }
+}

--- a/tests/Some/SignableHttpRequest.php
+++ b/tests/Some/SignableHttpRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PetrKnap\DataSigner\Some;
+
+use PetrKnap\DataSigner\SignableHttpRequest as Base;
+use Psr\Http\Message\RequestInterface;
+
+final class SignableHttpRequest extends Base
+{
+    private const SIGNABLE_HEADERS = [
+        'Host',
+        'X-User-Id',
+        'X-Timestamp',
+    ];
+
+    public function __construct(RequestInterface $request)
+    {
+        $uri = $request->getUri();
+        $query = $uri->getQuery();
+        parent::__construct(
+            method: $request->getMethod(),
+            uri: $uri->getPath() . ($query === '' ? '' : '?' . $query),
+            headers: array_filter(array_map(
+                $request->getHeaderLine(...),
+                array_combine(self::SIGNABLE_HEADERS, self::SIGNABLE_HEADERS),
+            )),
+            body: (string) $request->getBody(),
+        );
+    }
+}


### PR DESCRIPTION
- [x] This pull request does not contain any breaking change.
- [x] I asked [the AI](https://copilot.microsoft.com/) to briefly summarize, use and improve the feature(s), and I'm okay with the output:
<!-- ↓ here belongs the AI inputs (>>) and outputs (>) ↓ -->
>> Could you briefly summarize the following code for me?
>> ```php
>> /**
>>  * @note Defines a shared contract; implement your environment‑specific version.
>>  *
>>  * @see Some\SignableHttpRequest for inspiration
>>  */
>> abstract class SignableHttpRequest implements SignableDataInterface
>> {
>>     protected readonly string $method;
>>     /**
>>      * @var array<string, string>
>>      */
>>     protected readonly array $headers;
>> 
>>     /**
>>      * @param array<string, string> $headers
>>      */
>>     public function __construct(
>>         string $method,
>>         protected readonly string $uri,
>>         array $headers,
>>         protected readonly string $body,
>>     ) {
>>         $this->method = static::normalizeMethod($method);
>>         $this->headers = static::normalizeHeaders($headers);
>>     }
>> 
>>     /**
>>      * @return non-empty-string HTTP/1.1-like - headers are normalized by {@see static::normalizeHeaders()}
>>      *
>>      * @link https://datatracker.ietf.org/doc/html/rfc2616
>>      */
>>     public function toSignableData(): string
>>     {
>>         $http11Like = ["{$this->method} {$this->uri} HTTP/1.1"];
>>         foreach ($this->headers as $name => $value) {
>>             $http11Like[] = "{$name}: {$value}";
>>         }
>>         $http11Like[] = '';
>>         $http11Like[] = $this->body;
>> 
>>         return implode("\r\n", $http11Like);
>>     }
>> 
>>     /**
>>      * @param array<string, string> $headers
>>      *
>>      * @return array<string, string>
>>      */
>>     protected static function normalizeHeaders(array $headers): array
>>     {
>>         ksort($headers); // stabilize merge
>>         $normalizedHeaders = [];
>>         foreach ($headers as $name => $value) {
>>             $normalizedName = implode('-', array_map('ucfirst', explode('-', strtolower($name))));
>>             $stringValue = (string) $value;
>>             if (array_key_exists($normalizedName, $normalizedHeaders)) {
>>                 $normalizedHeaders[$normalizedName] .= ',' . $stringValue;
>>             } else {
>>                 $normalizedHeaders[$normalizedName] = $stringValue;
>>             }
>>         }
>>         ksort($normalizedHeaders); // stabilize output
>>         return $normalizedHeaders;
>>     }
>> 
>>     protected static function normalizeMethod(string $method): string
>>     {
>>         return strtoupper($method);
>>     }
>> }
>> ```
>
> This abstract `SignableHttpRequest` class defines a reusable blueprint for HTTP requests that need to be converted into a canonical, signable string.
>
> It ensures that any environment‑specific implementation produces *consistent, stable, and predictable* data for cryptographic signing—critical for authentication schemes like HMAC or custom signature protocols.
>
>> Could you show me how to use it?
> 
> Because the class is abstract, you can’t instantiate it directly. You create a concrete subclass that provides any environment‑specific behavior you need (or none at all, if the base behavior is enough).
> 
> ```php
> $request = new MySignableRequest(
>     method: 'post',
>     uri: '/api/v1/orders',
>     headers: [
>         'content-type' => 'application/json',
>         'x-custom' => 'abc',
>         'X-CUSTOM' => 'def', // will be merged into "X-Custom: abc,def"
>     ],
>     body: '{"id":123}'
> );
> 
> $signable = $request->toSignableData();
> 
> echo $signable;
> ```
> ```
> POST /api/v1/orders HTTP/1.1
> Content-Type: application/json
> X-Custom: abc,def
> 
> {"id":123}
> ```
>
>> Is there any way to design the abstract better?
>
> - **Separate “data container” from “canonicalization logic”**, right now the abstract class both stores request data and defines how to turn it into signable bytes. That makes it harder to:
>   - plug in different canonicalization strategies,
>   - support multiple signature versions,
>   - test normalization independently.
> - **Make normalization pluggable**, right now normalization is hard‑coded. If a future signature scheme requires:
>   - lowercase headers,
>   - sorted by value,
>   - or a different HTTP version line,
>   - you’d have to subclass and override static methods — not ideal.
